### PR TITLE
feat: prompt for key if anon PULL access fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp/
 client/sqlrsync
 client/sqlrsync
 client/sqlrsync_simple
+asciinema/

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,5 +1,5 @@
 # SQLite Rsync Go Client Makefile
-.PHONY: all build clean test deps check-deps install-deps run help
+.PHONY: all build clean test deps check-deps install-deps install run help
 
 # Build configuration
 BINARY_NAME := sqlrsync
@@ -55,6 +55,12 @@ build: $(SQLITE_RSYNC_LIB)
 	CGO_ENABLED=$(CGO_ENABLED) CGO_LDFLAGS="-L$(BRIDGE_LIB_DIR) -lsqlite_rsync" go build $(GOFLAGS) -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) $(MAIN_FILE)
 	@echo "✓ Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
 
+# Install the binary to system path
+install: build
+	@echo "Installing $(BINARY_NAME) to /usr/local/bin/..."
+	cp $(BUILD_DIR)/$(BINARY_NAME) /usr/local/bin/$(BINARY_NAME)
+	@echo "✓ Install complete: /usr/local/bin/$(BINARY_NAME)"
+
 # Build with debug symbols
 build-debug: check-deps
 	@echo "Building $(BINARY_NAME) with debug symbols..."
@@ -104,6 +110,7 @@ help:
 	@echo "  all          - Check dependencies and build (default)"
 	@echo "  build        - Build the binary"
 	@echo "  build-debug  - Build with debug symbols"
+	@echo "  install      - Build and install binary to /usr/local/bin"
 	@echo "  clean        - Remove build artifacts"
 	@echo "  deps         - Download Go dependencies"
 	@echo "  check-deps   - Check system dependencies"
@@ -118,5 +125,6 @@ help:
 	@echo "Usage examples:"
 	@echo "  make build"
 	@echo "  make run"
+	@echo "  make install"
 	@echo "  make run-dry"
 	@echo "  make test"

--- a/client/auth/config.go
+++ b/client/auth/config.go
@@ -166,16 +166,11 @@ func SaveLocalSecretsConfig(config *LocalSecretsConfig) error {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
-	file, err := os.Create(path)
+  file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create local-secrets config file %s: %w", path, err)
 	}
 	defer file.Close()
-
-	// Set file permissions to 0600 (read/write for owner only)
-	if err := file.Chmod(0600); err != nil {
-		return fmt.Errorf("failed to set permissions on local-secrets config file: %w", err)
-	}
 
 	encoder := toml.NewEncoder(file)
 	if err := encoder.Encode(config); err != nil {

--- a/client/auth/resolver.go
+++ b/client/auth/resolver.go
@@ -22,14 +22,14 @@ type ResolveResult struct {
 
 // ResolveRequest contains the parameters for authentication resolution
 type ResolveRequest struct {
-	LocalPath        string
-	RemotePath       string
-	ServerURL        string
-	ProvidedPullKey  string
-	ProvidedPushKey  string
+	LocalPath         string
+	RemotePath        string
+	ServerURL         string
+	ProvidedPullKey   string
+	ProvidedPushKey   string
 	ProvidedReplicaID string
-	Operation        string // "pull", "push", "subscribe"
-	Logger           *zap.Logger
+	Operation         string // "pull", "push", "subscribe"
+	Logger            *zap.Logger
 }
 
 // Resolver handles authentication and configuration resolution
@@ -87,7 +87,7 @@ func (r *Resolver) Resolve(req *ResolveRequest) (*ResolveResult, error) {
 		if req.ServerURL == "wss://sqlrsync.com" {
 			if localSecretsConfig, err := LoadLocalSecretsConfig(); err == nil {
 				if dbConfig := localSecretsConfig.FindDatabaseByPath(absLocalPath); dbConfig != nil {
-					r.logger.Debug("Using server URL from local secrets config", 
+					r.logger.Debug("Using server URL from local secrets config",
 						zap.String("configuredServer", dbConfig.Server),
 						zap.String("defaultServer", req.ServerURL))
 					result.ServerURL = dbConfig.Server
@@ -138,7 +138,7 @@ func (r *Resolver) Resolve(req *ResolveRequest) (*ResolveResult, error) {
 // resolveFromLocalSecrets attempts to resolve auth from local-secrets.toml
 func (r *Resolver) resolveFromLocalSecrets(absLocalPath, serverURL string, result *ResolveResult) (*ResolveResult, error) {
 	r.logger.Debug("Attempting to resolve from local secrets", zap.String("absLocalPath", absLocalPath), zap.String("serverURL", serverURL))
-	
+
 	localSecretsConfig, err := LoadLocalSecretsConfig()
 	if err != nil {
 		r.logger.Debug("Failed to load local secrets config", zap.Error(err))
@@ -162,8 +162,8 @@ func (r *Resolver) resolveFromLocalSecrets(absLocalPath, serverURL string, resul
 	}
 
 	if dbConfig.Server != serverURL {
-		r.logger.Debug("Server URL mismatch", 
-			zap.String("configured", dbConfig.Server), 
+		r.logger.Debug("Server URL mismatch",
+			zap.String("configured", dbConfig.Server),
 			zap.String("requested", serverURL))
 		return nil, fmt.Errorf("server URL mismatch: configured=%s, requested=%s", dbConfig.Server, serverURL)
 	}

--- a/client/auth/resolver.go
+++ b/client/auth/resolver.go
@@ -12,7 +12,7 @@ import (
 
 // ResolveResult contains the resolved authentication information
 type ResolveResult struct {
-	AccessToken    string
+	AccessKey    string
 	ReplicaID    string
 	ServerURL    string
 	RemotePath   string
@@ -53,9 +53,9 @@ func (r *Resolver) Resolve(req *ResolveRequest) (*ResolveResult, error) {
 	}
 
 	// 1. Try environment variable first
-	if token := os.Getenv("SQLRSYNC_AUTH_TOKEN"); token != "" {
-		r.logger.Debug("Using SQLRSYNC_AUTH_TOKEN from environment")
-		result.AccessToken = token
+	if key := os.Getenv("SQLRSYNC_AUTH_KEY"); key != "" {
+		r.logger.Debug("Using SQLRSYNC_AUTH_KEY from environment")
+		result.AccessKey = key
 		result.ReplicaID = req.ProvidedReplicaID
 		return result, nil
 	}
@@ -63,14 +63,14 @@ func (r *Resolver) Resolve(req *ResolveRequest) (*ResolveResult, error) {
 	// 2. Try explicitly provided keys
 	if req.ProvidedPullKey != "" {
 		r.logger.Debug("Using provided pull key")
-		result.AccessToken = req.ProvidedPullKey
+		result.AccessKey = req.ProvidedPullKey
 		result.ReplicaID = req.ProvidedReplicaID
 		return result, nil
 	}
 
 	if req.ProvidedPushKey != "" {
 		r.logger.Debug("Using provided push key")
-		result.AccessToken = req.ProvidedPushKey
+		result.AccessKey = req.ProvidedPushKey
 		result.ReplicaID = req.ProvidedReplicaID
 		return result, nil
 	}
@@ -114,7 +114,7 @@ func (r *Resolver) Resolve(req *ResolveRequest) (*ResolveResult, error) {
 	if req.Operation == "push" {
 		if os.Getenv("SQLRSYNC_ADMIN_KEY") != "" {
 			r.logger.Debug("Using SQLRSYNC_ADMIN_KEY from environment")
-			result.AccessToken = os.Getenv("SQLRSYNC_ADMIN_KEY")
+			result.AccessKey = os.Getenv("SQLRSYNC_ADMIN_KEY")
 			result.ShouldPrompt = false
 			return result, nil
 		}
@@ -126,7 +126,7 @@ func (r *Resolver) Resolve(req *ResolveRequest) (*ResolveResult, error) {
 
 	// 5. If it's a pull, maybe no key needed
 	if req.Operation == "pull" || req.Operation == "subscribe" {
-		result.AccessToken = ""
+		result.AccessKey = ""
 		result.ShouldPrompt = false
 		return result, nil
 	}
@@ -169,7 +169,7 @@ func (r *Resolver) resolveFromLocalSecrets(absLocalPath, serverURL string, resul
 	}
 
 	r.logger.Debug("Found authentication in local secrets config")
-	result.AccessToken = dbConfig.PushKey
+	result.AccessKey = dbConfig.PushKey
 	result.ReplicaID = dbConfig.ReplicaID
 	result.RemotePath = dbConfig.RemotePath
 	result.ServerURL = dbConfig.Server
@@ -193,7 +193,7 @@ func (r *Resolver) resolveFromDashFile(localPath string, result *ResolveResult) 
 	}
 
 	r.logger.Debug("Found authentication in -sqlrsync file")
-	result.AccessToken = dashSQLRsync.PullKey
+	result.AccessKey = dashSQLRsync.PullKey
 	result.ReplicaID = dashSQLRsync.ReplicaID
 	result.RemotePath = dashSQLRsync.RemotePath
 	result.ServerURL = dashSQLRsync.Server
@@ -201,24 +201,25 @@ func (r *Resolver) resolveFromDashFile(localPath string, result *ResolveResult) 
 	return result, nil
 }
 
-// PromptForAdminKey prompts the user for an admin key
-func (r *Resolver) PromptForAdminKey(serverURL string) (string, error) {
+// PromptForKey prompts the user for an key
+func (r *Resolver) PromptForKey(serverURL string, remotePath string, keyType string) (string, error) {
 	httpServer := strings.Replace(serverURL, "ws", "http", 1)
-	fmt.Println("No Key provided. Creating a new Replica? Get a key at " + httpServer + "/namespaces")
-	fmt.Print("   Enter an Account Admin Key to create a new Replica: ")
+	fmt.Println("Replica not found when using unauthenticated access.  Try again using a key or check your spelling.")
+	fmt.Println("   Get a key at " + httpServer + "/namespaces or " + httpServer + "/" + remotePath)
+	fmt.Print("   Provide a key to " + keyType + ": ")
 
 	reader := bufio.NewReader(os.Stdin)
-	token, err := reader.ReadString('\n')
+	key, err := reader.ReadString('\n')
 	if err != nil {
-		return "", fmt.Errorf("failed to read admin key: %w", err)
+		return "", fmt.Errorf("failed to read key: %w", err)
 	}
 
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return "", fmt.Errorf("admin key cannot be empty")
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", fmt.Errorf("key cannot be empty")
 	}
 
-	return token, nil
+	return key, nil
 }
 
 // SavePushResult saves the result of a successful push operation

--- a/client/main.go
+++ b/client/main.go
@@ -155,7 +155,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	// Create sync coordinator
 	coordinator := sync.NewCoordinator(&sync.CoordinatorConfig{
 		ServerURL:         serverURL,
-		ProvidedAuthToken: getAuthToken(),
+		ProvidedAuthKey:   getAuthKey(),
 		ProvidedPullKey:   pullKey,
 		ProvidedPushKey:   pushKey,
 		ProvidedReplicaID: replicaID,
@@ -224,10 +224,10 @@ func determineOperation(args []string) (sync.Operation, string, string, error) {
 	return sync.Operation(0), "", "", fmt.Errorf("invalid arguments")
 }
 
-func getAuthToken() string {
+func getAuthKey() string {
 	// Try environment variable first
-	if token := os.Getenv("SQLRSYNC_AUTH_TOKEN"); token != "" {
-		return token
+	if key := os.Getenv("SQLRSYNC_AUTH_KEY"); key != "" {
+		return key
 	}
 
 	// Try pull/push keys

--- a/client/sync/coordinator.go
+++ b/client/sync/coordinator.go
@@ -196,7 +196,7 @@ func (c *Coordinator) resolveAuth(operation string) (*auth.ResolveResult, error)
 	}
 
 	// If prompting is needed for push operations
-	if result.ShouldPrompt || operation == "push" {
+	if result.ShouldPrompt || (operation == "push" && result.AccessKey == "") {
 		key, err := c.authResolver.PromptForKey(c.config.ServerURL, c.config.RemotePath, "PUSH")
 		if err != nil {
 			return nil, err

--- a/client/sync/coordinator.go
+++ b/client/sync/coordinator.go
@@ -32,7 +32,7 @@ const (
 // CoordinatorConfig holds sync coordinator configuration
 type CoordinatorConfig struct {
 	ServerURL         string
-	ProvidedAuthToken string // Explicitly provided auth token
+	ProvidedAuthKey   string // Explicitly provided auth key
 	ProvidedPullKey   string // Explicitly provided pull key
 	ProvidedPushKey   string // Explicitly provided push key
 	ProvidedReplicaID string // Explicitly provided replica ID
@@ -133,10 +133,10 @@ func (c *Coordinator) displayDryRunInfo(operation string, authResult *auth.Resol
 
 	if operation != "local" {
 		fmt.Printf(" - Server:         %s\n", color.GreenString(serverURL))
-		if authResult.AccessToken != "" {
-			fmt.Printf(" - Access Token:   %s\n", color.GreenString(authResult.AccessToken))
+		if authResult.AccessKey != "" {
+			fmt.Printf(" - Access Key:     %s\n", color.GreenString(authResult.AccessKey))
 		} else {
-			fmt.Printf(" - Access Token:   %s\n", color.YellowString("(none)"))
+			fmt.Printf(" - Access Key:     %s\n", color.YellowString("(none)"))
 		}
 
 		if operation == "push" {
@@ -179,14 +179,14 @@ func (c *Coordinator) resolveAuth(operation string) (*auth.ResolveResult, error)
 		Logger:            c.logger,
 	}
 
-	// Try explicit auth token first
-	if c.config.ProvidedAuthToken != "" {
+	// Try explicit auth key first
+	if c.config.ProvidedAuthKey != "" {
 		return &auth.ResolveResult{
-			AccessToken: c.config.ProvidedAuthToken,
-			ReplicaID:   c.config.ProvidedReplicaID,
-			ServerURL:   c.config.ServerURL,
-			RemotePath:  c.config.RemotePath,
-			LocalPath:   c.config.LocalPath,
+			AccessKey:  c.config.ProvidedAuthKey,
+			ReplicaID:  c.config.ProvidedReplicaID,
+			ServerURL:  c.config.ServerURL,
+			RemotePath: c.config.RemotePath,
+			LocalPath:  c.config.LocalPath,
 		}, nil
 	}
 
@@ -196,12 +196,12 @@ func (c *Coordinator) resolveAuth(operation string) (*auth.ResolveResult, error)
 	}
 
 	// If prompting is needed for push operations
-	if result.ShouldPrompt && operation == "push" {
-		token, err := c.authResolver.PromptForAdminKey(c.config.ServerURL)
+	if result.ShouldPrompt || operation == "push" {
+		key, err := c.authResolver.PromptForKey(c.config.ServerURL, c.config.RemotePath, "PUSH")
 		if err != nil {
 			return nil, err
 		}
-		result.AccessToken = token
+		result.AccessKey = key
 		result.ShouldPrompt = false
 	}
 
@@ -245,7 +245,7 @@ func (c *Coordinator) executeSubscribe() error {
 	c.subManager = subscription.NewManager(&subscription.ManagerConfig{
 		ServerURL:             authResult.ServerURL,
 		ReplicaPath:           authResult.RemotePath,
-		AuthToken:             authResult.AccessToken,
+		AccessKey:             authResult.AccessKey,
 		ReplicaID:             authResult.ReplicaID,
 		WsID:                  c.config.WsID,
 		ClientVersion:         c.config.ClientVersion,
@@ -366,7 +366,7 @@ func (c *Coordinator) executePull(isSubscription bool) error {
 	// Create remote client for WebSocket transport
 	remoteClient, err := remote.New(&remote.Config{
 		ServerURL:               serverURL + "/sapi/pull/" + remotePath,
-		AuthToken:               authResult.AccessToken,
+		AuthKey:                 authResult.AccessKey,
 		ReplicaID:               authResult.ReplicaID,
 		Timeout:                 8000,
 		PingPong:                false, // No ping/pong needed for single sync
@@ -398,7 +398,17 @@ func (c *Coordinator) executePull(isSubscription bool) error {
 
 	// Connect to remote server
 	if err := remoteClient.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to server: %w", err)
+		if (strings.Contains(err.Error(), "key is not authorized") || strings.Contains(err.Error(), "404 Path not found")) && authResult.AccessKey == "" {
+			key, err := c.authResolver.PromptForKey(c.config.ServerURL, c.config.RemotePath, "PULL")
+			if err != nil {
+				return fmt.Errorf("coordinator failed to get key interactively: %w", err)
+			}
+			c.config.ProvidedAuthKey = key
+			return c.executePull(isSubscription)
+		} else {
+
+			return fmt.Errorf("coordinator failed to connect to server: %w", err)
+		}
 	}
 
 	// Create local client for SQLite operations
@@ -495,7 +505,7 @@ func (c *Coordinator) executePush() error {
 		ServerURL:               serverURL + "/sapi/push/" + remotePath,
 		PingPong:                true,
 		Timeout:                 15000,
-		AuthToken:               authResult.AccessToken,
+		AuthKey:                 authResult.AccessKey,
 		Logger:                  c.logger.Named("remote"),
 		EnableTrafficInspection: c.config.Verbose,
 		LocalHostname:           localHostname,
@@ -507,7 +517,7 @@ func (c *Coordinator) executePush() error {
 		CommitMessage:           c.config.CommitMessage,
 		WsID:                    c.config.WsID, // Add websocket ID
 		ClientVersion:           c.config.ClientVersion,
-		ProgressCallback:        nil,           //remote.DefaultProgressCallback(remote.FormatSimple),
+		ProgressCallback:        nil, //remote.DefaultProgressCallback(remote.FormatSimple),
 		ProgressConfig: &remote.ProgressConfig{
 			Enabled:        true,
 			Format:         remote.FormatSimple,

--- a/examples/earthquakes/gov.usgs.earthquakes.sh
+++ b/examples/earthquakes/gov.usgs.earthquakes.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# USGS Earthquake Data Synchronization Script
+# Downloads earthquake data every 50 minutes and syncs to SQLRsync
+
+# Configuration
+FILE=earthquakes.db
+TABLE=earthquakes
+UPDATES=50m
+URL=https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_month.csv
+SQLRSYNC_PATH=usgs.gov/earthquakes.db
+PRIMARY_KEY=id
+MODE="INSERT OR REPLACE INTO"
+SCHEMA="time TEXT, latitude REAL, longitude REAL, depth REAL, mag REAL, magType TEXT, nst INTEGER, gap REAL, dmin REAL, rms REAL, net TEXT, id TEXT PRIMARY KEY, updated TEXT, place TEXT, type TEXT, horizontalError REAL, depthError REAL, magError REAL, magNst INTEGER, status TEXT, locationSource TEXT, magSource TEXT"
+
+# Convert time interval to seconds for sleep
+convert_to_seconds() {
+    local time_str="$1"
+    local num="${time_str%[a-zA-Z]*}"
+    local unit="${time_str#$num}"
+    
+    case "$unit" in
+        s|sec) echo "$num" ;;
+        m|min) echo $((num * 60)) ;;
+        h|hour) echo $((num * 3600)) ;;
+        d|day) echo $((num * 86400)) ;;
+        *) echo 3000 ;; # default to 50 minutes
+    esac
+}
+
+# Initialize database and table
+init_database() {
+    echo "Initializing database: $FILE"
+    sqlite3 "$FILE" "CREATE TABLE IF NOT EXISTS $TABLE ($SCHEMA);"
+    if [ $? -eq 0 ]; then
+        echo "Database initialized successfully"
+    else
+        echo "Error: Failed to initialize database"
+        exit 1
+    fi
+}
+
+# Download and import data with in-memory staging
+sync_data() {
+    echo "$(date): Downloading earthquake data from USGS..."
+    
+    # Download CSV data
+    local temp_file=$(mktemp)
+    if curl -s -f "$URL" -o "$temp_file"; then
+        echo "Data downloaded successfully"
+        
+        # Get record count before import
+        local count_before=$(sqlite3 "$FILE" "SELECT COUNT(*) FROM $TABLE;" 2>/dev/null || echo "0")
+        
+        # Use in-memory database for staging to avoid bloating main database
+        sqlite3 "$FILE" <<EOF
+-- Attach in-memory database for staging
+ATTACH DATABASE ':memory:' AS staging;
+
+-- Create staging table in memory with same schema
+CREATE TABLE staging.$TABLE ($SCHEMA);
+
+-- Import CSV data into in-memory staging table
+.mode csv
+.import $temp_file staging.$TABLE
+
+-- Remove header row if it was imported (check if id column contains 'id')
+DELETE FROM staging.$TABLE WHERE id = 'id';
+
+-- Use INSERT OR REPLACE to merge data from in-memory staging to main table
+$MODE main.$TABLE 
+SELECT * FROM staging.$TABLE;
+
+-- Detach in-memory database (automatically cleans up)
+DETACH DATABASE staging;
+EOF
+        
+        if [ $? -eq 0 ]; then
+            local count_after=$(sqlite3 "$FILE" "SELECT COUNT(*) FROM $TABLE;")
+            local new_records=$((count_after - count_before))
+            echo "Data imported successfully. Total records: $count_after (added/updated: $new_records)"
+            
+            # Show some recent earthquake info
+            echo "Recent earthquakes:"
+            sqlite3 "$FILE" "SELECT time, mag, place FROM $TABLE ORDER BY time DESC LIMIT 3;" 2>/dev/null | head -3
+            
+            # Sync to SQLRsync server if path is configured
+            if [ -n "$SQLRSYNC_PATH" ] && command -v sqlrsync >/dev/null 2>&1; then
+                echo "Syncing to SQLRsync server: $SQLRSYNC_PATH"
+                sqlrsync "$FILE" "$SQLRSYNC_PATH"
+                if [ $? -eq 0 ]; then
+                    echo "Successfully synced to server"
+                else
+                    echo "Warning: Failed to sync to server"
+                fi
+            fi
+        else
+            echo "Error: Failed to import data"
+        fi
+    else
+        echo "Error: Failed to download data from $URL"
+    fi
+    
+    rm -f "$temp_file"
+}
+
+# Main execution
+main() {
+    echo "Fetch CSV to SQLite Data Sync Starting..."
+    echo "Configuration:"
+    echo "  Database: $FILE"
+    echo "  Table: $TABLE" 
+    echo "  Update interval: $UPDATES"
+    echo "  Data source: $URL"
+    echo "  SQLRsync path: $SQLRSYNC_PATH"
+    echo ""
+    
+    # Initialize database
+    init_database
+    
+    # Convert update interval to seconds
+    local sleep_seconds=$(convert_to_seconds "$UPDATES")
+    echo "Update interval: $sleep_seconds seconds"
+    echo ""
+    
+    # Initial sync
+    sync_data
+    
+    # Continuous sync loop
+    echo "Starting continuous sync (Ctrl+C to stop)..."
+    while true; do
+        echo "Sleeping for $UPDATES ($sleep_seconds seconds)..."
+        sleep "$sleep_seconds"
+        sync_data
+    done
+}
+
+# Run main function if script is executed directly
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi
+

--- a/examples/earthquakes/gov.usgs.earthquakes.sh
+++ b/examples/earthquakes/gov.usgs.earthquakes.sh
@@ -8,6 +8,7 @@ FILE=earthquakes.db
 TABLE=earthquakes
 UPDATES=50m
 URL=https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_month.csv
+URL=https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.csv
 SQLRSYNC_PATH=usgs.gov/earthquakes.db
 PRIMARY_KEY=id
 MODE="INSERT OR REPLACE INTO"

--- a/examples/earthquakes/gov.usgs.earthquakes.sh
+++ b/examples/earthquakes/gov.usgs.earthquakes.sh
@@ -53,26 +53,14 @@ sync_data() {
         local count_before=$(sqlite3 "$FILE" "SELECT COUNT(*) FROM $TABLE;" 2>/dev/null || echo "0")
         
         # Use in-memory database for staging to avoid bloating main database
-        sqlite3 "$FILE" <<EOF
--- Attach in-memory database for staging
-ATTACH DATABASE ':memory:' AS staging;
-
--- Create staging table in memory with same schema
-CREATE TABLE staging.$TABLE ($SCHEMA);
-
--- Import CSV data into in-memory staging table
+        sqlite3 ":memory:" <<EOF
+-- Import CSV data into in-memory temp table
 .mode csv
-.import $temp_file staging.$TABLE
+.import $temp_file incoming
 
--- Remove header row if it was imported (check if id column contains 'id')
-DELETE FROM staging.$TABLE WHERE id = 'id';
-
--- Use INSERT OR REPLACE to merge data from in-memory staging to main table
-$MODE main.$TABLE 
-SELECT * FROM staging.$TABLE;
-
--- Detach in-memory database (automatically cleans up)
-DETACH DATABASE staging;
+-- Use INSERT OR REPLACE to merge data from in-memory temp to main table
+ATTACH DATABASE "$FILE" AS c;
+INSERT OR REPLACE INTO c.earthquakes SELECT * FROM incoming;
 EOF
         
         if [ $? -eq 0 ]; then


### PR DESCRIPTION
Now that we support public/unlisted PULLs, we can't always ask for the key.  It doesn't feel good to have to rerun the command if we do need a key, so prompt once for a key before failing the command.

This PR also:
- renames token to key where needed
- added the example usgs.gov/earthquakes so I could have new data to pull/subscribe to to test
- adds a `make install` to make testing easier