### PR TITLE
feat: check integrity before push and after pull

### DIFF
--- a/bridge/cgo_bridge.go
+++ b/bridge/cgo_bridge.go
@@ -65,6 +65,36 @@ func cgoGetDatabaseInfo(dbPath string) (*DatabaseInfo, error) {
 
 	return info, nil
 }
+// SQLRSYNC
+// CheckIntegrity checks the database integrity using PRAGMA integrity_check
+func CheckIntegrity(dbPath string) (bool, string, error) {
+	return cgoCheckIntegrity(dbPath)
+}
+
+// SQLRSYNC
+// cgoCheckIntegrity checks the database integrity using PRAGMA integrity_check
+func cgoCheckIntegrity(dbPath string) (bool, string, error) {
+	cDbPath := C.CString(dbPath)
+	defer C.free(unsafe.Pointer(cDbPath))
+
+	const errorMsgSize = 1024
+	errorMsg := make([]byte, errorMsgSize)
+	cErrorMsg := (*C.char)(unsafe.Pointer(&errorMsg[0]))
+
+	result := C.sqlite_rsync_check_integrity(cDbPath, cErrorMsg, C.int(errorMsgSize))
+	
+	switch result {
+	case 0:
+		return true, "", nil // Database is OK
+	case 1:
+		return false, C.GoString(cErrorMsg), nil // Database is corrupted
+	default:
+		return false, C.GoString(cErrorMsg), &SQLiteRsyncError{
+			Code:    int(result),
+			Message: "failed to check database integrity",
+		}
+	}
+}
 
 // RunOriginSync wraps the C function to run origin synchronization
 func RunOriginSync(dbPath string, dryRun bool, client *BridgeClient) error {

--- a/bridge/client.go
+++ b/bridge/client.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 )
@@ -70,6 +71,32 @@ func (c *BridgeClient) GetDatabaseInfo() (*DatabaseInfo, error) {
 	return info, nil
 }
 
+// CheckIntegrity checks the database integrity using PRAGMA integrity_check
+func (c *BridgeClient) CheckIntegrity() (bool, string, error) {
+	c.Logger.Debug("Checking database integrity", zap.String("path", c.Config.DatabasePath))
+
+	if _, err := os.Stat(c.Config.DatabasePath); os.IsNotExist(err) {
+		return false, "", fmt.Errorf("database file does not exist: %s", c.Config.DatabasePath)
+	}
+
+	fmt.Println("🐛 CHECKING INTEGRITY BEFORE PUSH")
+	isOk, errorMsg, err := CheckIntegrity(c.Config.DatabasePath)
+	if err != nil {
+		c.Logger.Error("Failed to check database integrity", zap.Error(err))
+		return false, "", err
+	}
+
+	if !isOk {
+		c.Logger.Warn("Database integrity check failed",
+			zap.String("database", c.Config.DatabasePath),
+			zap.String("error", errorMsg))
+		return false, errorMsg, nil
+	}
+
+	c.Logger.Debug("Database integrity check passed", zap.String("database", c.Config.DatabasePath))
+	return true, "", nil
+}
+
 // RunPushSync runs the origin-side synchronization with provided I/O functions
 func (c *BridgeClient) RunPushSync(readFunc ReadFunc, writeFunc WriteFunc) error {
 	c.Logger.Info("Starting origin sync", zap.String("database", c.Config.DatabasePath))
@@ -117,7 +144,7 @@ func (c *BridgeClient) RunPullSync(readFunc ReadFunc, writeFunc WriteFunc) error
 		return err
 	}
 
-	c.Logger.Info("Replica sync completed successfully")
+	c.Logger.Info("Replica sync completed")
 	return nil
 }
 

--- a/bridge/sqlite_rsync_wrapper.c
+++ b/bridge/sqlite_rsync_wrapper.c
@@ -132,6 +132,63 @@ int sqlite_rsync_get_db_info(const char *db_path, sqlite_db_info_t *info)
   sqlite3_close(db);
   return 0;
 }
+// SQLRSYNC
+// Check database integrity using PRAGMA integrity_check
+int sqlite_rsync_check_integrity(const char *db_path, char *error_msg, int error_msg_size)
+{
+  if (!db_path || !error_msg)
+  {
+    return -1;
+  }
+
+  // Initialize error message
+  error_msg[0] = '\0';
+
+  sqlite3 *db;
+  int rc = sqlite3_open_v2(db_path, &db, SQLITE_OPEN_READONLY, NULL);
+  if (rc != SQLITE_OK)
+  {
+    if (error_msg_size > 0)
+    {
+      snprintf(error_msg, error_msg_size, "Cannot open database: %s", sqlite3_errmsg(db));
+    }
+    if (db)
+      sqlite3_close(db);
+    return -1;
+  }
+
+  sqlite3_stmt *stmt;
+  rc = sqlite3_prepare_v2(db, "PRAGMA integrity_check", -1, &stmt, NULL);
+  if (rc != SQLITE_OK)
+  {
+    if (error_msg_size > 0)
+    {
+      snprintf(error_msg, error_msg_size, "Cannot prepare integrity check: %s", sqlite3_errmsg(db));
+    }
+    sqlite3_close(db);
+    return -1;
+  }
+
+  int result = 0; // Assume OK
+  while (sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const char *result_text = (const char *)sqlite3_column_text(stmt, 0);
+    if (result_text && strcmp(result_text, "ok") != 0)
+    {
+      // Database is corrupted
+      result = 1;
+      if (error_msg_size > 0)
+      {
+        snprintf(error_msg, error_msg_size, "Integrity check failed: %s", result_text);
+      }
+      break;
+    }
+  }
+
+  sqlite3_finalize(stmt);
+  sqlite3_close(db);
+  return result;
+}
 
 // Cleanup resources
 void sqlite_rsync_cleanup(void)

--- a/bridge/sqlite_rsync_wrapper.h
+++ b/bridge/sqlite_rsync_wrapper.h
@@ -78,6 +78,10 @@ extern "C"
 
   int sqlite_rsync_get_db_info(const char *db_path, sqlite_db_info_t *info);
 
+  // SQLRSYNC: Check database integrity using PRAGMA integrity_check
+  // Returns 0 if OK, 1 if corrupted, -1 on error
+  int sqlite_rsync_check_integrity(const char *db_path, char *error_msg, int error_msg_size);
+
   // Cleanup resources
   void sqlite_rsync_cleanup(void);
 

--- a/client/sync/coordinator.go
+++ b/client/sync/coordinator.go
@@ -427,6 +427,16 @@ func (c *Coordinator) executePull(isSubscription bool) error {
 	if err := c.performPullSync(localClient, remoteClient); err != nil {
 		return fmt.Errorf("pull synchronization failed: %w", err)
 	}
+
+	// Check database integrity after pull
+	isOk, errorMsg, err := localClient.CheckIntegrity()
+	if err != nil {
+		return fmt.Errorf("failed to check local database integrity: %w", err)
+	}
+	if !isOk {
+		return fmt.Errorf("database is corrupt: %s", errorMsg)
+	}
+
 	c.config.Version = remoteClient.GetVersion()
 	// Save pull result if needed
 	if remoteClient.GetNewPullKey() != "" && c.authResolver.CheckNeedsDashFile(c.config.LocalPath, remotePath) {
@@ -450,9 +460,25 @@ func (c *Coordinator) executePull(isSubscription bool) error {
 
 // executePush performs a push sync operation
 func (c *Coordinator) executePush() error {
-	// Validate that database file exists
-	if _, err := os.Stat(c.config.LocalPath); os.IsNotExist(err) {
-		return fmt.Errorf("database file does not exist: %s", c.config.LocalPath)
+	// Create local client for SQLite operations
+	localClient, err := bridge.New(&bridge.BridgeConfig{
+		DatabasePath:             c.config.LocalPath,
+		DryRun:                   c.config.DryRun,
+		Logger:                   c.logger.Named("local"),
+		EnableSQLiteRsyncLogging: c.config.Verbose,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create local client: %w", err)
+	}
+	defer localClient.Close()
+
+	// Check database integrity before pushing
+	isOk, errorMsg, err := localClient.CheckIntegrity()
+	if err != nil {
+		return fmt.Errorf("failed to check local database integrity: %w", err)
+	}
+	if !isOk {
+		return fmt.Errorf("cannot create local client because integrity check failed: %s", errorMsg)
 	}
 
 	// Resolve authentication
@@ -472,18 +498,6 @@ func (c *Coordinator) executePush() error {
 	if c.config.RemotePath != "" {
 		remotePath = c.config.RemotePath
 	}
-
-	// Create local client for SQLite operations
-	localClient, err := bridge.New(&bridge.BridgeConfig{
-		DatabasePath:             c.config.LocalPath,
-		DryRun:                   c.config.DryRun,
-		Logger:                   c.logger.Named("local"),
-		EnableSQLiteRsyncLogging: c.config.Verbose,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create local client: %w", err)
-	}
-	defer localClient.Close()
 
 	// Get absolute path for the local database
 	absLocalPath, err := filepath.Abs(c.config.LocalPath)


### PR DESCRIPTION
For PUSH: check integrity when coordinator creates the local client
For PULL: check integrity after coordinator finishes the PULL but before dashfile creation
For LOCAL: No change